### PR TITLE
fix + bug

### DIFF
--- a/decode-qr-uri.py
+++ b/decode-qr-uri.py
@@ -40,6 +40,7 @@ except:
 enc = False
 try:
     enc = query['enc'][0]
+    enc = enc.replace(" ","+")
 except:
     raise Exception('An "enc" parameter is a required part of the URI')
 


### PR DESCRIPTION
The URL does not contain a Base64-URL enoded string, so URLLib will parse it wrong ("+" is parsed into " "). This quick and dirty patch fixes that.